### PR TITLE
Ot101 68 activity details screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@testing-library/user-event": "^13.5.0",
     "axios": "^0.24.0",
     "formik": "^2.2.9",
+    "html-react-parser": "^1.4.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-redux": "^7.1.3",

--- a/src/App.js
+++ b/src/App.js
@@ -7,7 +7,7 @@ import { Box } from '@mui/system';
 import { publicRoutes, backofficeRoutes } from './routes';
 import PublicLayout from './components/PublicLayout';
 import Backoffice from './pages/Backoffice';
-import Register from './pages/Register';
+
 
 function App() {
 	const { isTokenVerified } = useSelector(state => state.user)

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -71,7 +71,7 @@ const Footer = ({ routes }) => {
               {tempSocials.map((social) => {
                 const Icon = iconsType[social.icon];
                 return (
-                  <MenuItem>
+                  <MenuItem key={social.icon}>
                     <a href={social.url}>
                       <Icon sx={{ margin: 1, color: 'white' }} />
                     </a>

--- a/src/pages/ActivityDetails.jsx
+++ b/src/pages/ActivityDetails.jsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import parse from 'html-react-parser';
+
+import { Box, Container, Typography } from '@material-ui/core'
+import CircularProgress from '@mui/material/CircularProgress';
+
+import { getRequest } from '../services/requestsHandlerService';
+
+
+const ActivityDetails = () => {
+    const { id } = useParams();
+    const [ activity, setActivity ] = useState();
+    const [ isLoading, setIsLoading ] = useState(true);
+
+
+    useEffect(() => {
+        let disposed = false;
+
+        const fetchDetails = async () => {
+            try {
+                const details = await getRequest(`/activities/${id}`);
+
+                if (disposed) return; // avoid state change in a unmounted component
+
+                setActivity(details);
+            } catch (err) {
+                console.log(err);
+            } finally {
+                setIsLoading(false);
+            }
+        };
+        fetchDetails();
+
+        return () => disposed = true;
+    }, []);
+
+    if (isLoading) {
+        return (
+            <CircularProgress sx={{ mx: 'auto', my: 'auto', display: 'block' }} size={64} />
+        );
+    }
+
+    if (!activity) {
+        return (
+            <Typography variant="h3" align='center' style={{marginTop: '30vh'}}>
+                No existen detalles sobre dicha actividad
+            </Typography>
+        );
+    }
+
+    return (
+        <Container maxwidth='lg' align='center'>
+            <img src={activity.image} alt='activity' style={{margin: '50px 0', maxWidth: '100%'}}/>
+            <Typography variant="h3" gutterBottom>{activity.name}</Typography>
+            <Box align='left'>
+            { parse(activity.content) }
+            </Box>
+        </Container>
+    );
+
+
+};
+
+export default ActivityDetails;

--- a/src/pages/BackofficeNews.js
+++ b/src/pages/BackofficeNews.js
@@ -14,7 +14,7 @@ import Switch from '@mui/material/Switch';
 import { getRequest } from '../services/requestsHandlerService';
 import { EnhancedTableToolbar } from '../components/ScreenTables/EnhancedTableToolbar';
 import { EnhancedTableHead } from '../components/ScreenTables/EnhancedTableHead';
-import headCellNews from '../components/ScreenTables/HeadCellsNews';
+import headCellNews from '../components/ScreenTables/headCellsNews';
 
 function createData(idKey, name, image, createAt) {
   return {

--- a/src/routes.js
+++ b/src/routes.js
@@ -9,6 +9,8 @@ import Testimonials from './pages/Testimonials';
 import Register from './pages/Register';
 import BackofficeActivities from './pages/BackofficeActivities';
 
+import ActivityDetails from './pages/ActivityDetails';
+
 import BackofficeHome from './pages/backoffice/BackofficeHome';
 import BackofficeDummy from './pages/backoffice/BackofficeDummy';
 import BackofficeCategories from './pages/BackofficeCategories';
@@ -35,6 +37,7 @@ const publicRoutes = [
   { name: 'Inicio', path: '/', element: <Home /> },
   { name: 'Sobre nosotros', path: '/about', element: <About /> },
   { name: 'Actividades', path: '/activities', element: <Activities /> },
+  { path: '/Actividades/:id', element: <ActivityDetails /> },
   { name: 'Novedades', path: '/Novedades', element: <News /> },
   { name: 'Testimonios', path: '/testimonials', element: <Testimonials /> },
   { name: 'Contacto', path: '/contact', element: <Contact /> },


### PR DESCRIPTION
COMO: Usuario
QUIERO: Ver los detalles de la actividad
PARA: Tener mas conocimiento sobre ella

Criterios de aceptación: Al ingresar a la ruta /Actividades/:id . Mostrará el detalle de la actividad, obteniendo los datos desde el endpoint. En el caso de que la actividad no exista, mostrará un mensaje de error.

* Add screen to fetch and show activity details
* Fix errors and warning located in other places.

**New mpm package installed, run `npm install` after this merge.**