### PR TITLE
Ot101 104 routes transitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "axios": "^0.24.0",
     "babel": "^6.23.0",
     "formik": "^2.2.9",
+    "framer-motion": "^4.1.17",
     "html-react-parser": "^1.4.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/src/App.js
+++ b/src/App.js
@@ -1,54 +1,57 @@
 import React from 'react';
-import { BrowserRouter, Route, Routes } from 'react-router-dom';
-import { useSelector } from 'react-redux';
+import { BrowserRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { AnimatePresence } from "framer-motion";
+import FadeIn from './components/FadeIn';
 //import RouteProtection from './components/RouteProtection';
-import CircularProgress from '@mui/material/CircularProgress';
-import { Box } from '@mui/system';
 import { publicRoutes, backofficeRoutes } from './routes';
 import PublicLayout from './components/PublicLayout';
 import Backoffice from './pages/Backoffice';
 
+
+const AnimatedRoutes = () => {
+  const location = useLocation();
+
+  return (
+    <AnimatePresence exitBeforeEnter>
+      <Routes location={location} key={location.pathname}>
+        <Route path="/" element={<PublicLayout routes={publicRoutes} />}>
+          {publicRoutes.map(({ path, element }) => (
+            <Route key={path} path={path} element={<FadeIn>{element}</FadeIn>} />
+          ))}
+        </Route>
+        { /* Code to use when login process is functional
+        <Route
+          path="/backoffice"
+          element={
+            <RouteProtection roles={['user', 'admin']}>
+              <FadeIn><Backoffice routes={backofficeRoutes} /></FadeIn>
+            </RouteProtection>
+          }
+        >
+          {backofficeRoutes.map(({ path, element, roles }) => (
+            <Route
+              key={path}
+              path={path}
+              element={<RouteProtection roles={roles}><FadeIn>{element}</FadeIn></RouteProtection>}
+            />
+          ))}
+        </Route>
+        */ }
+        <Route path="/backoffice" element={<Backoffice routes={backofficeRoutes} />}>
+          {backofficeRoutes.map(({ path, element, roles }) => (
+            <Route key={path} path={path} element={<FadeIn>{element}</FadeIn>} />
+          ))}
+        </Route>
+      </Routes>
+    </AnimatePresence>
+  );
+
+}
+
 function App() {
-	const { isTokenVerified } = useSelector(state => state.user)
-  
   return (
     <BrowserRouter>
-      {!isTokenVerified ? (
-        <Box sx={{ height: '100vh', display: 'flex' }}>
-          <CircularProgress sx={{ mx: 'auto', my: 'auto', display: 'block' }} size={64} />
-        </Box>
-      ) : (
-        <Routes>
-          <Route path="/" element={<PublicLayout routes={publicRoutes} />}>
-            {publicRoutes.map(({ path, element }) => (
-              <Route key={path} path={path} element={element} />
-            ))}
-          </Route>
-          { /* Code to use when login process is functional
-          <Route
-            path="/backoffice"
-            element={
-              <RouteProtection roles={['user', 'admin']}>
-                <Backoffice routes={backofficeRoutes} />
-              </RouteProtection>
-            }
-          >
-            {backofficeRoutes.map(({ path, element, roles }) => (
-              <Route
-                key={path}
-                path={path}
-                element={<RouteProtection roles={roles}>{element}</RouteProtection>}
-              />
-            ))}
-          </Route>
-          */ }
-          <Route path="/backoffice" element={<Backoffice routes={backofficeRoutes} />}>
-            {backofficeRoutes.map(({ path, element, roles }) => (
-              <Route key={path} path={path} element={element} />
-            ))}
-          </Route>
-        </Routes>
-      )}
+      <AnimatedRoutes />
     </BrowserRouter>
   );
 }

--- a/src/components/FadeIn.jsx
+++ b/src/components/FadeIn.jsx
@@ -1,0 +1,14 @@
+import { motion } from "framer-motion";
+
+
+const FadeIn = ({children}) => (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+    >
+      { children }
+    </motion.div>
+);
+
+export default FadeIn;

--- a/src/components/PublicLayout.js
+++ b/src/components/PublicLayout.js
@@ -1,6 +1,6 @@
 import Footer from './Footer';
 import Header from './Header';
-import { CircularProgress, Container } from '@mui/material';
+import { LinearProgress, Container } from '@mui/material';
 import { Box } from '@mui/system';
 import { Outlet } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
@@ -15,14 +15,7 @@ export default function PublicLayout({ routes }) {
     dispatch(fetchData());
   }, []);
 
-  return organization.isFetching ? (
-    <Box sx={{ height: '100vh', display: 'flex' }}>
-      <CircularProgress
-        sx={{ mx: 'auto', my: 'auto', display: 'block' }}
-        size={64}
-      />
-    </Box>
-  ) : (
+  return (
     <Box
       sx={{
         display: 'flex',
@@ -33,6 +26,9 @@ export default function PublicLayout({ routes }) {
       }}
     >
       <Header routes={routes} />
+      { organization.isFetching && 
+        <LinearProgress />
+      }
       <Container sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column' }}>
         {<Outlet />}
       </Container>


### PR DESCRIPTION
COMO: Usuario
QUIERO: Visualizar transiciones al moverme entre rutas
PARA: Mejorar la experiencia de usuario

Criterios de aceptación: El navegador SPA renderiza el contenido de forma instantánea. Para mejorar la experiencia de usuario, agregar una transición (por ejemplo, fade in) que renderice el contenido de la ruta de una forma animada. Esto debe ser agregado de forma global, y no en cada componente existente. Ver librería que puede ajustarse a este requerimiento.

Observaciones:
- react-router v6 tiene soporte acotado para animaciones en las rutas, menos aún en rutas anidadas. Por eso no se pudo utilizar react-router-transition y se debió aplicar la animación a las subrutas de PublicLayout y Backoffice.
- se cambió el Spinner de PublicLayout por un LinearProgress, debajo del navbar, para evitar los flashes de pantalla del spinner.
- **se debe ejecutar npm install o yarn por la dependencia agregada**
